### PR TITLE
chore: doesn't replace deepin-wallpapers and deepin-wallpapers-nonfree

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,9 +18,6 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends},
 Breaks: deepin-desktop-base (<< 2017.11.2)
-Replaces: deepin-wallpapers, deepin-wallpapers-nonfree
-Conflicts: deepin-wallpapers, deepin-wallpapers-nonfree
-Provides: deepin-wallpapers, deepin-wallpapers-nonfree
 Description: When users are ready to set their own desktop background,
  The dde Wallpaper provides a beautiful background pictures.
  It is part of Deepin software and DDE (Deepin Desktop Environment).


### PR DESCRIPTION
重新划分了这几个软件包的责任:

- `dde-wallpapers` 提供 dde 的核心壁纸，例如默认壁纸。

- `deepin-wallpapers` 提供扩展的、可供移植的授权壁纸。

- `deepin-wallpapers-nonfree` 提供扩展的、不可移植的壁纸。

@shao-jun 需要同步一下信息，桌面环境的虚包 `deepin-desktop-environment` 应该同步依赖这三个壁纸包。